### PR TITLE
Introduce Github Actions CI workflow for the ggml repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    runs-on: ${{ matrix.os }}
+
+    env:
+      GGML_NLOOP: 35
+      GGML_NITER: 1
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set GGML_NTHREADS for Ubuntu
+      run: echo "GGML_NTHREADS=2" >> $GITHUB_ENV
+      if: matrix.os == 'ubuntu-latest'
+
+    - name: Set GGML_NTHREADS for MacOS
+      run: echo "GGML_NTHREADS=3" >> $GITHUB_ENV
+      if: matrix.os == 'macos-latest'
+
+    - name: Create Build Environment
+      run: mkdir build
+
+    - name: Configure CMake
+      working-directory: ./build
+      run: cmake ..
+
+    - name: Build
+      working-directory: ./build
+      run: make
+
+    - name: Test
+      working-directory: ./build
+      run: ctest --verbose --timeout 900

--- a/tests/test-grad0.c
+++ b/tests/test-grad0.c
@@ -350,7 +350,7 @@ int main(int argc, const char ** argv) {
 
     // original loop: 1000
     int niter = 4;
-    const char *env = getenv("GGML_NLOOP");
+    const char *env = getenv("GGML_NITER");
     if (env != NULL) {
         niter = atoi(env);
     }


### PR DESCRIPTION
This commit integrates a Github Actions CI workflow that compiles and tests the codebase on both Ubuntu 22.04 and macOS 12 Monterey. The workflow is triggered on pull requests against the main branch and on every push to the main branch.

To accommodate the resource constraints of the Github-hosted runners, a `GGML_NITER` environment variable is introduced, allowing tests to run within a reasonable time frame. `test-grad0.c` is modified to use this variable instead of `GGML_NLOOP`.

The workflow file includes:

- A build strategy for both Ubuntu and MacOS.
- An environment setup with variables `GGML_NLOOP` and `GGML_NITER`.
- A step to limit the number of threads used by `test2.c` for efficient execution.
- A typical build process with steps for environment creation, CMake configuration, building, and verbose testing with a timeout.